### PR TITLE
feat: add on-chain affiliate verification fallback

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -9,6 +9,7 @@ import { SignaturesController } from "./controllers/signatures.controller"
 import { AffiliateService } from "./services/affiliate.service"
 import { SignatureService } from "./services/signature.service"
 import { SignaturesService } from "./signatures/signatures.service"
+import { OnChainService } from "./utils/on-chain"
 import { Affiliate, AffiliateSchema } from "./schemas/affiliate.schema"
 import { Signature, SignatureSchema } from "./schemas/signature.schema"
 
@@ -36,6 +37,7 @@ import { Signature, SignatureSchema } from "./schemas/signature.schema"
         AffiliateService,
         SignatureService,
         SignaturesService,
+        OnChainService,
     ],
 })
 export class AppModule {}

--- a/server/src/config/configuration.ts
+++ b/server/src/config/configuration.ts
@@ -11,6 +11,7 @@ export default () => ({
         contract: "0xd36a37a5c116ef661a84bd2314b4ef59e1a0f307",
         chainId: 56,
     },
+    bscRpcUrl: process.env.BSC_RPC_URL || "https://bsc-dataseed.binance.org",
     isDevelopmentMode: process.env.NODE_ENV !== "production",
     mongoUri: process.env.MONGO_URI || "mongodb://localhost:27017/referral",
 })

--- a/server/src/services/affiliate.service.ts
+++ b/server/src/services/affiliate.service.ts
@@ -9,11 +9,13 @@ import { Affiliate } from "../schemas/affiliate.schema"
 import { CreateAffiliateDto } from "../dto/create-affiliate.dto"
 import { CreateAliasDto } from "../dto/create-alias.dto"
 import { getAddress, Hex, recoverTypedDataAddress } from "viem"
+import { OnChainService } from "../utils/on-chain"
 
 @Injectable()
 export class AffiliateService {
     constructor(
         @InjectModel(Affiliate.name) private affiliateModel: Model<Affiliate>,
+        private onChainService: OnChainService,
     ) {}
 
     async create(createAffiliateDto: CreateAffiliateDto): Promise<Affiliate> {
@@ -70,9 +72,17 @@ export class AffiliateService {
             throw new ConflictException("Alias already taken")
         }
 
-        const affiliate = await this.affiliateModel.findOne({ address }).exec()
+        let affiliate = await this.affiliateModel.findOne({ address }).exec()
         if (!affiliate) {
-            throw new BadRequestException("Affiliate not found")
+            const isAffiliate = await this.onChainService.isAffiliate(address)
+            if (!isAffiliate) {
+                throw new BadRequestException("Affiliate not found")
+            }
+            affiliate = await this.affiliateModel.findOneAndUpdate(
+                { address },
+                { $setOnInsert: { address } },
+                { upsert: true, new: true },
+            )
         }
         if (affiliate.alias) {
             throw new BadRequestException("Affiliate already has an alias")

--- a/server/src/services/signature.service.ts
+++ b/server/src/services/signature.service.ts
@@ -7,6 +7,7 @@ import {
 import { InjectModel } from "@nestjs/mongoose"
 import { Model } from "mongoose"
 import { recoverTypedDataAddress, Hex } from "viem"
+import { OnChainService } from "../utils/on-chain"
 import { Signature } from "../schemas/signature.schema"
 import { Affiliate } from "../schemas/affiliate.schema"
 import { StoreSignatureDto } from "../dto/store-signature.dto"
@@ -17,6 +18,7 @@ export class SignatureService {
     constructor(
         @InjectModel(Signature.name) private signatureModel: Model<Signature>,
         @InjectModel(Affiliate.name) private affiliateModel: Model<Affiliate>,
+        private onChainService: OnChainService,
     ) {}
 
     async store(
@@ -31,11 +33,21 @@ export class SignatureService {
             )
         }
 
-        const affiliate = await this.affiliateModel
+        let affiliate = await this.affiliateModel
             .findOne({ address: storeSignatureDto.affiliate })
             .exec()
         if (!affiliate) {
-            throw new NotFoundException("Affiliate not found")
+            const isAffiliate = await this.onChainService.isAffiliate(
+                storeSignatureDto.affiliate,
+            )
+            if (!isAffiliate) {
+                throw new NotFoundException("Affiliate not found")
+            }
+            affiliate = await this.affiliateModel.findOneAndUpdate(
+                { address: storeSignatureDto.affiliate },
+                { $setOnInsert: { address: storeSignatureDto.affiliate } },
+                { upsert: true, new: true },
+            )
         }
 
         // Validate the signature

--- a/server/src/utils/on-chain.ts
+++ b/server/src/utils/on-chain.ts
@@ -1,0 +1,64 @@
+import {
+    Injectable,
+    OnModuleInit,
+    ServiceUnavailableException,
+} from "@nestjs/common"
+import { ConfigService } from "@nestjs/config"
+import { createPublicClient, getAddress, Hex, http } from "viem"
+import { bsc } from "viem/chains"
+
+const USER_TIER_ABI = [
+    {
+        inputs: [{ name: "", type: "address" }],
+        name: "userTier",
+        outputs: [{ name: "", type: "uint256" }],
+        stateMutability: "view",
+        type: "function",
+    },
+] as const
+
+function createBscClient(rpcUrl: string) {
+    return createPublicClient({
+        chain: bsc,
+        transport: http(rpcUrl, { timeout: 5000 }),
+    })
+}
+
+@Injectable()
+export class OnChainService implements OnModuleInit {
+    private readContract: (typeof createBscClient extends (
+        ...args: infer _
+    ) => infer R
+        ? R
+        : never)["readContract"]
+    private contract: Hex
+
+    constructor(private configService: ConfigService) {}
+
+    onModuleInit() {
+        const rpcUrl = this.configService.get<string>("bscRpcUrl")
+        this.contract = this.configService.get<string>(
+            "referrals.contract",
+        ) as Hex
+        const client = createBscClient(rpcUrl)
+        this.readContract = client.readContract.bind(client)
+    }
+
+    async isAffiliate(userAddress: string): Promise<boolean> {
+        try {
+            const tier = await this.readContract({
+                address: this.contract,
+                abi: USER_TIER_ABI,
+                functionName: "userTier",
+                args: [getAddress(userAddress)],
+            })
+
+            return tier > 0n
+        } catch (error) {
+            console.error("On-chain affiliate check failed:", error)
+            throw new ServiceUnavailableException(
+                "Unable to verify on-chain affiliate status",
+            )
+        }
+    }
+}


### PR DESCRIPTION
When a MongoDB affiliate record is missing (e.g. after cleanup), verify affiliate status on-chain via userTier before rejecting. Auto-creates the MongoDB record if on-chain tier > 0.

- Add OnChainService with reusable BSC client and 5s timeout
- Apply fallback in both affiliate.service and signature.service
- Use findOneAndUpdate with upsert to prevent race conditions
- Add BSC_RPC_URL config with public fallback